### PR TITLE
Add 'desserts' column to 'food' table

### DIFF
--- a/add_desserts_column.sql
+++ b/add_desserts_column.sql
@@ -1,0 +1,10 @@
+-- Add 'desserts' column to 'food' table
+ALTER TABLE food
+ADD COLUMN desserts VARCHAR NOT NULL DEFAULT 'Unknown';
+
+-- Remove the default constraint after adding the column
+ALTER TABLE food
+ALTER COLUMN desserts DROP DEFAULT;
+
+-- Comment explaining the change
+COMMENT ON COLUMN food.desserts IS 'Stores information about desserts related to the food item';


### PR DESCRIPTION
This PR adds a new 'desserts' column to the 'food' table in our PostgreSQL database. The column is of type VARCHAR and is set to NOT NULL.

Changes made:
1. Created a new SQL file 'add_desserts_column.sql'
2. Added ALTER TABLE statement to add the 'desserts' column
3. Used a DEFAULT value of 'Unknown' to handle existing rows
4. Removed the DEFAULT constraint after adding the column
5. Added a COMMENT to explain the purpose of the new column

Please review and approve these changes.